### PR TITLE
Fix version number crash on newer perls

### DIFF
--- a/User.pm
+++ b/User.pm
@@ -113,10 +113,10 @@ sub sendsplash {
   $this->sendnumeric($this->server,1,
    "Welcome to the Internet Relay Network ".$this->nick);
   $this->sendnumeric($this->server,2,
-   "Your host is ".$this->server->{name}.", running version ".$this->server->VERSION);
+   "Your host is ".$this->server->{name}.", running version pircd ".$this->server->VERSION);
   $this->sendnumeric($this->server,3,
    "This server was created ".scalar gmtime($this->server->creation));
-  $this->sendnumeric($this->server,4,($this->server->{name},$this->server->VERSION,"dioswkg","biklmnopstv"),undef);
+  $this->sendnumeric($this->server,4,($this->server->{name},'pircd-'.$this->server->VERSION,"dioswkg","biklmnopstv"),undef);
   # Send them LUSERS output
   $this->handle_lusers("LUSERS");
   $this->privmsgnotice("NOTICE",$this->server,"Highest connection count: ".$Utils::stats{highconnections}." (".$Utils::stats{highclients}." clients)");

--- a/Utils.pm
+++ b/Utils.pm
@@ -32,7 +32,7 @@ tie my %channels, 'Tie::IRCUniqueHash';
 
 my $syslogsetup = 0;
 
-$VERSION="pircd-beta-0";
+$VERSION="v0.9";
 %params=(syslog=>0,		# use syslog for log messages?
 	 logfile=>undef,	# filename for log, use STDERR if undef
 	 );


### PR DESCRIPTION
It appears that version 0.014 of Module::Runtime introduces some
unfortunate behavior, as described here:
  https://rt.cpan.org/Public/Bug/Display.html?id=92989

When running pircd with a newer version of perl including this version
of Module::Runtime, the server dies as soon as it tries to print the
splash information, with this message:
  Invalid version format (non-numeric data) at User.pm line 115.

Though that bug is still open at this time, it may not get fixed soon,
so this change stops the crash and makes us compliant with the
specification of version numbers as given here:
  http://search.cpan.org/~jpeacock/version/lib/version.pod

A few potential points of discussion:

You know I'm loathe to give up pircd's versioning scheme, but it seems to have been forced upon us, unless we rename Util's VERSION to something else.

Given the number of years pircd has been in production, I was tempted to set the version to 1.0, but I decided to use a more conservative choice.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jkominek/pircd/1)

<!-- Reviewable:end -->
