### PR TITLE
Send RPL_NOTOPIC when no topic is set

### DIFF
--- a/Channel.pm
+++ b/Channel.pm
@@ -492,7 +492,12 @@ sub join {
   #do the actual join
   $this->force_join($user,$user->server);
 
-  $user->sendnumeric($user->server,332,$this->{'name'},$this->{'topic'}) if defined $this->{'topic'};
+  if (defined $this->{'topic'}) {
+    $user->sendnumeric($user->server,332,$this->{'name'},$this->{'topic'});
+  } else {
+    $user->sendnumeric($user->server,331,$this->{'name'},'No topic is set');
+  }
+
   $user->sendnumeric($user->server,333,$this->{'name'},$this->{'topicsetter'},$this->{'topicsettime'},undef) if defined $this->{'topicsetter'};
   if(1==scalar keys(%{$this->{'users'}})) {
     $this->setop($user,$user->nick());


### PR DESCRIPTION
Per RFC 2812, as if anyone ever paid attention to that:
  https://tools.ietf.org/html/rfc2812#page-46

I don't think this actually matters; most clients don't even know about this response and at least some other servers don't send it, but I thought I'd suggest it anyway.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jkominek/pircd/3)

<!-- Reviewable:end -->
