### PR TITLE
Fixes for recent perl

### DIFF
--- a/Channel.pm
+++ b/Channel.pm
@@ -17,7 +17,6 @@ use Utils;
 use User;
 use Server;
 use strict;
-use UNIVERSAL qw(isa);
 
 use Tie::IRCUniqueHash;
 
@@ -189,7 +188,7 @@ sub setop {
   my ($this,$user,$target) = @_;
   my $ret    = Utils::lookupuser($target,1);
 
-  if(!(ref($ret) && isa($ret,"User"))) {
+  if(!(ref($ret) && $ret->isa("User"))) {
     $user->sendnumeric($user->server,401,$target,"No such nick");
     return undef;
   }
@@ -210,7 +209,7 @@ sub unsetop {
   my ($this,$user,$target) = @_;
   my $ret    = Utils::lookupuser($target,1);
 
-  if(!(ref($ret) && isa($ret,"User"))) {
+  if(!(ref($ret) && $ret->isa("User"))) {
     $user->sendnumeric($user->server,401,$target,"No such nick");
     return undef;
   }
@@ -243,7 +242,7 @@ sub setvoice {
   my ($this,$user,$target) = @_;
   my $ret    = Utils::lookupuser($target,1);
 
-  if(!(ref($ret) && isa($ret,"User"))) {
+  if(!(ref($ret) && $ret->isa("User"))) {
     $user->sendnumeric($user->server,401,$target,"No such nick");
     return undef;
   }
@@ -265,7 +264,7 @@ sub unsetvoice {
   my $user   = shift;
   my $target = shift;
   my $ret    = Utils::lookupuser($target,1);
-  if(!(ref($ret) && isa($ret,"User"))) {
+  if(!(ref($ret) && $ret->isa("User"))) {
     $user->sendnumeric($user->server,401,$target,"No such nick");
     return undef;
   }

--- a/Connection.pm
+++ b/Connection.pm
@@ -16,7 +16,6 @@ package Connection;
 use Utils;
 use Socket;
 use strict;
-use UNIVERSAL qw(isa);
 
 # Class constructor
 sub new {
@@ -225,7 +224,7 @@ sub sendreply {
   my($this,$src,@replies)=@_;
   my($reply,$fromstr,$repcode,$data,$destnick);
 
-  ($src,@replies)=(undef,$src,@replies) if(!ref($src) || !isa($src,"User"));
+  ($src,@replies)=(undef,$src,@replies) if(!ref($src) || !$src->isa("User"));
   
   defined($destnick=$this->{nick}) or $destnick='*';
   

--- a/LocalServer.pm
+++ b/LocalServer.pm
@@ -19,7 +19,6 @@ use Server;
 use strict;
 use Utils;
 use vars qw(@ISA $VERSION);
-use UNIVERSAL qw(isa);
 @ISA=qw{Server};
 
 use Tie::IRCUniqueHash;

--- a/Server.pm
+++ b/Server.pm
@@ -17,7 +17,6 @@ use Utils;
 use User;
 use Channel;
 use strict;
-use UNIVERSAL qw(isa);
 
 use Tie::IRCUniqueHash;
 

--- a/User.pm
+++ b/User.pm
@@ -19,8 +19,6 @@ use Utils;
 use Server;
 use Channel;
 
-use UNIVERSAL qw(isa);
-
 use Tie::IRCUniqueHash;
 
 my $commands = {'PONG'    => sub { },
@@ -195,7 +193,7 @@ sub msg_or_notice {
     } else {
       # ..lookup the associated object..
       my $tmp = Utils::lookup($target);
-      if(isa($tmp,"User")||isa($tmp,"Channel")) {
+      if($tmp->isa("User")||$tmp->isa("Channel")) {
 	  # ..and if it is a user or a channel (since they're the only things
 	  #  that can handle receiving a private message), dispatch it to them.
 	  $tmp->privmsgnotice($string,$this,$msg);
@@ -360,8 +358,8 @@ sub handle_invite {
   
   my $tmpchan = Utils::lookupchannel($channel);
   my $user    = Utils::lookupuser($nick);
-  if($user && isa($user,"User")) {
-    if($tmpchan && isa($tmpchan,"Channel")) {
+  if($user && $user->isa("User")) {
+    if($tmpchan && $tmpchan->isa("Channel")) {
       if(!$this->onchan($tmpchan)) {
 	$this->sendnumeric($this->server,442,$this->{name},$tmpchan->{name},"You're not on that channel");
 	return;
@@ -395,7 +393,7 @@ sub handle_whois {
     my @targets = split(/,/,$excess[0]);
     foreach my $target (@targets) {
       my $user = Utils::lookupuser($target);
-      if(defined($user) && isa($user, "User")) {
+      if(defined($user) && $user->isa("User")) {
 	# *** Nick is user@host (Irc Name)
 	$this->sendnumeric($this->server,311,($user->nick,$user->username,$user->host,"*"),$user->ircname);
 	# *** on channels: #foo @#bar +#baz
@@ -1147,14 +1145,14 @@ sub privmsgnotice {
   my $msg  = shift;
 
   if($this->{'socket'}) {
-    if(isa($from,"User")) {
+    if($from->isa("User")) {
       $this->senddata(":".$from->nick."!".$from->username."\@".$from->host." $string ".$this->nick." :$msg\r\n");
 
       if($this->away() && $string eq "PRIVMSG") {
 	$from->sendnumeric($this->server,301,$this->nick,$this->away);
       }
 
-    } elsif(isa($from,"Server")) {
+    } elsif($from->isa("Server")) {
       $this->senddata(":".$from->{name}." $string ".$this->nick." :$msg\r\n");
     }
   } else {
@@ -1243,7 +1241,7 @@ sub quit {
   # and announce it to local channels
   foreach my $channame (keys(%{$this->{'hasinvitation'}})) {
     my $channel = Utils::lookupchannel($channame);
-    if(ref($channel) && isa($channel,"Channel")) {
+    if(ref($channel) && $channel->isa("Channel")) {
       delete($channel->{'hasinvitation'}->{$this});
     }
   }

--- a/Utils.pm
+++ b/Utils.pm
@@ -18,7 +18,6 @@ package Utils;
 #use Server;
 #use Channel;
 use Sys::Syslog ();
-use UNIVERSAL qw(isa);
 use strict;
 use vars qw($VERSION %params);
 

--- a/pircd
+++ b/pircd
@@ -13,6 +13,8 @@
 #####################################################################
 
 use strict; # keeps me honest. :)
+use FindBin;
+use lib $FindBin::Bin;
 
 # Various what-not that we need to get things done.
 use POSIX;

--- a/pircd
+++ b/pircd
@@ -20,7 +20,6 @@ use IO::Socket;
 use IO::Select;
 use Fcntl;
 use Tie::RefHash;
-use UNIVERSAL qw(isa);
 
 # pircd-specific modules
 use Utils;


### PR DESCRIPTION
This (with the other PRs applied) should allow pircd to run on perl 5.26 and beyond.