### PR TITLE
Fix a crash on PRIVMSG of a non-existent nick or channel

### DIFF
--- a/User.pm
+++ b/User.pm
@@ -193,7 +193,7 @@ sub msg_or_notice {
     } else {
       # ..lookup the associated object..
       my $tmp = Utils::lookup($target);
-      if($tmp->isa("User")||$tmp->isa("Channel")) {
+      if(defined($tmp) && ($tmp->isa("User")||$tmp->isa("Channel"))) {
 	  # ..and if it is a user or a channel (since they're the only things
 	  #  that can handle receiving a private message), dispatch it to them.
 	  $tmp->privmsgnotice($string,$this,$msg);


### PR DESCRIPTION
This would have been introduced when I tried to get pircd running on
perl 5.22 and above, in commit
  fbb69134c88efc474a0c361870fb36706a597037

There may be other cases where the same problem was introduced, but I
didn't see them after a quick grep.