### PR TITLE
fix the misformatting of LIST 322 responses when the channel has no topic

### DIFF
--- a/User.pm
+++ b/User.pm
@@ -561,7 +561,8 @@ sub handle_list {
       my @topicdata = $channels{$channel}->topic;
       $this->sendnumeric($this->server,322,
 			 ($channels{$channel}->{name},
-			  scalar $channels{$channel}->users),$topicdata[0]);
+			  scalar $channels{$channel}->users),
+                         ($topicdata[0] or ""));
     }
   }
   $this->sendnumeric($this->server,323,"End of /LIST");


### PR DESCRIPTION
When $topicdata[0] is undef, sendnumeric omits the : which is the problem. So, (undef or "") prevents that.

Reasonable?